### PR TITLE
Adding shadow jar plugin to create standalone jars.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 import org.gradle.internal.os.OperatingSystem
 
 plugins {
+	 id 'com.github.johnrengelman.shadow' version '6.0.0'
     id 'java'
     id 'application'
 }
@@ -94,6 +95,13 @@ dependencies {
 	runtimeOnly "org.lwjgl:lwjgl-xxhash::$lwjglNatives"
 	runtimeOnly "org.lwjgl:lwjgl-yoga::$lwjglNatives"
 	runtimeOnly "org.lwjgl:lwjgl-zstd::$lwjglNatives"
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'jin.HelloLWJGL'
+    }
+    archiveName = 'jin.jar'
 }
 
 application {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.gradle.internal.os.OperatingSystem
 
 plugins {
-	 id 'com.github.johnrengelman.shadow' version '6.0.0'
+	id 'com.github.johnrengelman.shadow' version '6.0.0'
     id 'java'
     id 'application'
 }
@@ -97,11 +97,17 @@ dependencies {
 	runtimeOnly "org.lwjgl:lwjgl-zstd::$lwjglNatives"
 }
 
-jar {
-    manifest {
-        attributes 'Main-Class': 'jin.HelloLWJGL'
-    }
-    archiveName = 'jin.jar'
+task makeJar(type: Jar) {
+	manifest {
+		attributes 'Main-Class': 'jin.HelloLWJGL'
+		attributes 'Description': 'This is an application JAR'
+	}
+}
+
+shadowJar {
+  manifest {
+    inheritFrom project.tasks.makeJar.manifest
+  }
 }
 
 application {


### PR DESCRIPTION
With this plugin we can create a so called "fat jar" that contains all the dependencies of the project as well as the project classes so the application can be distributed by simply sharing this jar.

The command to issue is:

gradle shadowJar