### PR TITLE
Getting rid of Trove.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,5 @@ dependencies {
 
 	implementation "org.joml:joml:${jomlVersion}"
 
-	// https://mvnrepository.com/artifact/net.sf.trove4j/trove4j
-	implementation group: 'net.sf.trove4j', name: 'trove4j', version: '3.0.3'
 }
 

--- a/src/main/java/jin/model/UniformManager.java
+++ b/src/main/java/jin/model/UniformManager.java
@@ -2,7 +2,9 @@ package jin.model;
 
 import static org.lwjgl.opengl.GL20.*;
 
-import gnu.trove.map.hash.THashMap;
+import java.util.HashMap;
+import java.util.Map;
+
 import java.nio.IntBuffer;
 import org.lwjgl.system.MemoryStack;
 
@@ -73,7 +75,7 @@ public class UniformManager {
 		public void setLocation(int location) { this.location = location; }
 	}
 
-	private THashMap<String, UniformData> uniforms;
+	private Map<String, UniformData> uniforms;
 	private int programId;
 
 	/**
@@ -81,7 +83,7 @@ public class UniformManager {
 	 * @param programId the ID of the program that is parsed for uniforms
 	 */
 	public UniformManager(int programId) {
-		uniforms = new THashMap<>();
+		uniforms = new HashMap<>();
 		this.programId = programId;
 	}
 


### PR DESCRIPTION
Getting rid of Trove which is not developed anymore (the IntelliJ team maintains a fork but not much is happening there either).

Guava is used anyway, so efficient containers can be used from there, or, if need be, Eclipse Collections can be used.